### PR TITLE
Added method to use to existing libuv instance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 
 [features]
 skip-pkg-config = ["libuv-sys2/skip-pkg-config"]
+sys = []
 
 [badges]
 travis-ci = { repository = "bmatcuk/libuv-rs" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,11 @@ extern crate bitflags;
 #[macro_use]
 extern crate libuv_sys2 as uv;
 
+#[cfg(feature = "sys")]
+pub mod sys {
+    pub use super::uv::*;
+}
+
 macro_rules! callbacks {
     ($($v:vis $Name:ident($($($a:ident: $T:ty),+)?)$( -> $TReturn:ty)?);+;) => {
         $(__callback! {

--- a/src/loop.rs
+++ b/src/loop.rs
@@ -109,6 +109,14 @@ impl Loop {
         Ok(r#loop)
     }
 
+    // connect to an existing libuv instance
+    pub unsafe fn from_external(handle: *mut uv_loop_t) -> Self {
+        Self {
+            handle,
+            should_drop: false,
+        }
+    }
+
     /// Returns the initialized default loop.
     ///
     /// This function is just a convenient way for having a global loop throughout an application,


### PR DESCRIPTION
Hi all, this PR adds a method to construct a `Loop` from an existing pointer address.

My use case is reusing the Libuv bindings you have with an existing libuv instance - specifically, I am writing a Nodejs native addon and want to reuse the bindings offered by this package.

Used here from my fork: https://github.com/napi-rs/napi-rs/pull/2154/files#diff-1e236034b744d0ce6068c6b239c36a821d5550789289a8715c70c61c7ff9bbadR56

Testing this locally with a Nodejs add on works as expected