### PR TITLE
Change pointer type to std::os::raw::c_char to fix compilation on arm64/aarch64 targets

### DIFF
--- a/src/requests/fs.rs
+++ b/src/requests/fs.rs
@@ -108,7 +108,7 @@ impl FsReq {
     pub fn real_path(&self) -> Option<String> {
         match self.request_type() {
             crate::FsType::READLINK | crate::FsType::REALPATH => {
-                let ptr: *const i8 = unsafe { uv_fs_get_ptr(self.req) } as _;
+                let ptr: *const std::os::raw::c_char = unsafe { uv_fs_get_ptr(self.req) } as _;
                 Some(unsafe { CStr::from_ptr(ptr).to_string_lossy().into_owned() })
             }
             _ => None,


### PR DESCRIPTION
Building for `aarch64` targets (e.g. `aarch64-linux-android`) fails with a type mismatch error:
```
error[E0308]: mismatched types
 --> src/requests/fs.rs:112:46
  |
  | Some(unsafe { CStr::from_ptr(ptr).to_string_lossy().into_owned() })
  |               -------------- ^^^ expected `*const u8`, found `*const i8`
```

This happens because `c_char` is `i8` on most x86 but `u8` on like ARM. Hardcoding `*const i8` breaks compilation on those targets.

Fixes #7
